### PR TITLE
Check GU(b) >= epoch(t) - 2 at the epoch boundary

### DIFF
--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -291,6 +291,11 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
             if store.unrealized_justifications[head].epoch + 1 < current_epoch:
                 break
 
+        # Check GU(b) >= epoch(t) - 2 if slot(t) == first_slot(epoch(t))
+        if block_epoch < current_epoch and get_current_slot(store) % SLOTS_PER_EPOCH == 0:
+            if store.unrealized_justifications[block_root].epoch + 1 < current_epoch:
+                break
+
         if not is_one_confirmed(store, block_root):
             break
         


### PR DESCRIPTION
This check is required because if during the current epoch `GU(head) >= epoch(t) - 2`, but `GU(b) < epoch(t) - 2`, there is a possibility that the `head` block exists only in the view of a validator `v` and hasn’t yet been received by all other honest validators. In this case `b` will filtered out by all other honest validators at time `t`. Thus, we can’t confirm `b` in this case unless `GU(b) >= epoch(t) - 2`.

Once we move on to the next slot, this check becomes unnecessary as honest validators must vote in the support of `b` to match the `is_one_confirmed` condition; but since they vote for `b` it is clear that `b` isn’t filtered out in their view.

Essentially, any canonical block `b’` for which `is_one_confirmed(b’) == True`, i.e. observed by honest validators, such that `vs(b’, epoch(t)) >= epoch(t) - 2` would be sufficient to ensure that `b` isn’t filtered out in the view of honest validator `v’`. The check introduced in this PR is stricter than that and may prevent previous epoch blocks from being confirmed.

Thus, we should think about different way of processing previous epoch blocks, like finding the most advanced LMD confirmed block from the previous epoch as the first step, then running `GU(b’) >= epoch(t) - 2` check over that block and if this check succeeds move on to the current epoch blocks.