### PR TITLE
Check GU(b) >= epoch(t) - 2 at the epoch boundary. Take 2

### DIFF
--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -296,6 +296,13 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
         
         confirmed_root = block_root
 
+    # Check that previous epoch block won't be filtered out in the view of any honest validator
+    # at the beginning of the first slot of the current epoch
+    confirmed_epoch = compute_epoch_at_slot(store.blocks[confirmed_root].slot)
+    if confirmed_epoch < current_epoch and get_current_slot(store) % SLOTS_PER_EPOCH == 0:
+        if store.unrealized_justifications[confirmed_root].epoch + 1 < current_epoch:
+            return latest_confirmed_root
+
     return confirmed_root
 
 


### PR DESCRIPTION
Supersedes https://github.com/mkalinin/confirmation-rule/pull/8.

At the beginning of the first slot of the current epoch a block $b$ can get filtered out in the view of an honest validator $v’$ even though $b = highestLMDConfirmedDesc_v(b_{anchor}, t) \wedge b \in filt^{t,v}_{hfc}$. This can happen in the case when $GU(b) < epoch(t) - 2$ and block $b’$ such that $b' \succeq b \wedge GU(b’) \geq epoch(t) - 2$ has been observed by a validator $v$ just recently and isn’t yet in the view of $v’$.

To prevent confirming block $b$ in this case we should check that $\exists b’ \in \nu^{v, st(slot(t) - 1)}: b’  \succeq b \wedge GU(b’) \geq epoch(t) - 2$. So, assuming synchrony there was enough time for $b’$ to be disseminated to all honest validators, but we don’t have access to the view at the beginning of the previous slot.

Thus, we have to use another condition: $\exists b’ \in \nu^{v, st(slot(t))}: b’ \succeq b \wedge is\\_one\\_confirmed_v(b’) \wedge GU(b’) \geq epoch(t) - 2$. In this case $is\\_one\\_confirmed_v(b’)$ guarantees that $\exists b’ \in \nu^{v', vote(slot(t) - 1)}$ which is slightly stricter than $\exists b’ \in \nu^{v, st(slot(t) - 1)}$.

For the sake of simplicity, in the proposed change we check that $b' = highestLMDConfirmedDesc_v(b_{anchor}, t)$ satisfies $GU(b') \geq epoch(t) - 2$. This is stricter than $is\\_one\\_confirmed_v(b') \wedge GU(b') \geq epoch(t) - 2$, because it requires not only $b’$ but also each of its ancestor $b’'$ to also satisfy $is\\_one\\_confirmed_v(b’')$.