### PR TITLE
Deduplicate code in methods 

### DIFF
--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -315,7 +315,7 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
     current_epoch = get_current_store_epoch(store)
 
     # verify the latest confirmed block is not too old 
-    assert compute_block_epoch(latest_confirmed_root) + 1 >= current_epoch
+    assert get_block_epoch(latest_confirmed_root) + 1 >= current_epoch
 
     head = get_head(store)
     confirmed_root = latest_confirmed_root
@@ -335,7 +335,7 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
         # move towards the head in attempt to advance confirmed block
         # and stop when the first unconfirmed descendant is encountered        
         for block_root in canonical_roots:        
-            block_epoch = compute_epoch_at_slot(store.blocks[block_root].slot)
+            block_epoch = get_block_epoch(block_root)
             
             # If we reach the current epoch, we exit as this code is only for confirming blocks from the previous epoch
             if block_epoch == current_epoch:
@@ -360,8 +360,8 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
         tentative_confirmed_root = confirmed_root
 
         for block_root in canonical_roots:
-            block_epoch = compute_epoch_at_slot(store.blocks[block_root].slot)
-            tentative_confirmed_epoch = compute_epoch_at_slot(store.blocks[tentative_confirmed_root].slot)
+            block_epoch = get_block_epoch(block_root)
+            tentative_confirmed_epoch = get_block_epoch(tentative_confirmed_root)
             
             # The following condition can only be true the first time that we advance to a block from the current epoch
             if block_epoch > tentative_confirmed_epoch:
@@ -417,7 +417,7 @@ def get_latest_confirmed(store: Store) -> Root:
         confirmed_root = store.prev_slot_unrealized_justified_checkpoint.root
 
     # attempt to further advance the latest confirmed block
-    confirmed_block_epoch = compute_epoch_at_slot(store.blocks[confirmed_root].slot)
+    confirmed_block_epoch = get_block_epoch(confirmed_root)
     if confirmed_block_epoch + 1 >= current_epoch:
         return find_latest_confirmed_descendant(store, confirmed_root)
     else:

--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -327,7 +327,7 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
         # retrieve suffix of the canonical chain
         # verify the latest_confirmed_root belongs to it
         canonical_roots = get_canonical_roots(store, confirmed_root)
-        assert canonical_roots.pop(0) == ancestor_root
+        assert canonical_roots.pop(0) == confirmed_root
 
         # starting with the child of the latest_confirmed_root
         # move towards the head in attempt to advance confirmed block

--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -68,7 +68,7 @@ def get_block_epoch(store: Store, root: Root) -> Epoch:
     return compute_epoch_at_slot(store.blocks[root].slot)
 
 def get_checkpoint_for_block(store: Store, root: Root, epoch: Epoch) -> Checkpoint:
-    return Checkpoint(get_checkpoint_block(store, root, epoch). epoch)
+    return Checkpoint(get_checkpoint_block(store, root, epoch), epoch)
 
 
 def get_weight(store: Store, root: Root, checkpoint_state: BeaconState = None) -> Gwei:

--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -102,12 +102,10 @@ def is_full_validator_set_covered(first_slot: Slot, last_slot: Slot) -> bool:
     """
     Returns whether the range from ``first_slot`` to ``last_slot`` (inclusive of both) includes an entire epoch
     """
-    start_epoch = compute_epoch_at_slot(first_slot)
-    end_epoch = compute_epoch_at_slot(last_slot)
+    start_full_epoch = compute_epoch_at_slot(first_slot + (SLOTS_PER_EPOCH - 1))
+    end_full_epoch = compute_epoch_at_slot(last_slot + 1) # exclusive
 
-    return (
-        end_epoch > start_epoch + 1
-        or (end_epoch == start_epoch + 1 and is_first_slot_in_epoch(first_slot)))
+    return start_full_epoch < end_full_epoch
 
 
 def adjust_committee_weight_estimate_to_ensure_safety(estimate: Gwei) -> Gwei:

--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -402,6 +402,7 @@ def get_latest_confirmed(store: Store) -> Root:
     # either of the above conditions signifies that confirmation rule assumptions (at least synchrony) are broken
     # and already confirmed block might not be safe to use hence revert to the safest one which is the finalized block
     # this reversal trades monotonicity in favour of safety in the casey of asynchrony in the network
+    confirmed_block_epoch = get_block_epoch(store, confirmed_root)
     head = get_head(store)
     if confirmed_block_epoch + 1 < current_epoch or not is_ancestor(store, head, confirmed_root):
         confirmed_root = store.finalized_checkpoint.root

--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -295,8 +295,7 @@ def will_no_conflicting_checkpoint_be_justified(store: Store, checkpoint: Checkp
 
 def get_canonical_roots(store: Store, ancestor_root: Root) -> Sequence[Root]:
     """
-    Returns a suffix of the canonical chain starting from ``ancestor_root``
-    Fails if ``ancestor_root`` is not on the canonical chain
+    Returns a suffix of the canonical chain starting from ``ancestor_root`` (included at index 0)
     """
     ancestor_slot = get_block_slot(store, ancestor_root)
     root = get_head(store)
@@ -304,8 +303,6 @@ def get_canonical_roots(store: Store, ancestor_root: Root) -> Sequence[Root]:
     while store.blocks[root].slot > ancestor_slot:
         root = store.blocks[root].parent_root
         canonical_roots.insert(0, root)
-
-    assert canonical_roots.pop(0) == ancestor_root
 
     return canonical_roots
 
@@ -332,6 +329,7 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
         # retrieve suffix of the canonical chain
         # verify the latest_confirmed_root belongs to it
         canonical_roots = get_canonical_roots(store, confirmed_root)
+        assert canonical_roots.pop(0) == ancestor_root
 
         # starting with the child of the latest_confirmed_root
         # move towards the head in attempt to advance confirmed block

--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -188,7 +188,7 @@ def is_one_confirmed(store: Store, block_root: Root) -> bool:
     )
 
 
-def get_checkpoint_weight(store: Store, checkpoint: checkpoint_state, checkpoint_state: BeaconState) -> Gwei:
+def get_checkpoint_weight(store: Store, checkpoint: Checkpoint, checkpoint_state: BeaconState) -> Gwei:
     """
     Uses LMD-GHOST votes to estimate FFG support for a checkpoint.
     """

--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -67,6 +67,9 @@ def get_block_epoch(store: Store, root: Root) -> Epoch:
     assert root in store.blocks
     return compute_epoch_at_slot(store.blocks[root].slot)
 
+def get_checkpoint_for_block(store: Store, root: Root, epoch: Epoch) -> Checkpoint:
+    return Checkpoint(get_checkpoint_block(store, root, epoch). epoch)
+
 
 def get_weight(store: Store, root: Root, checkpoint_state: BeaconState = None) -> Gwei:
     """
@@ -195,10 +198,7 @@ def get_checkpoint_weight(store: Store, checkpoint: Checkpoint, checkpoint_state
 
     checkpoint_weight = 0
     for validator_index, latest_message in store.latest_messages.items():
-        vote_target = Checkpoint(
-            root=get_checkpoint_block(store, latest_message.root, latest_message.epoch),
-            epoch=latest_message.epoch
-        )
+        vote_target = get_checkpoint_for_block(store, latest_message.root, latest_message.epoch)
         # checkpoint matches vote's target
         if checkpoint == vote_target:
             checkpoint_weight += checkpoint_state.validators[validator_index].effective_balance
@@ -321,7 +321,7 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
     if (get_block_epoch(store, confirmed_root) + 1 == current_epoch
         and get_voting_source(store, store.prev_slot_head).epoch + 2 >= current_epoch 
         and (is_first_slot_in_epoch(get_current_slot(store))
-             or (will_no_conflicting_checkpoint_be_justified(store, get_checkpoint_block(store, head, current_epoch))
+             or (will_no_conflicting_checkpoint_be_justified(store, get_checkpoint_for_block(store, head, current_epoch))
                  and (store.unrealized_justifications[store.prev_slot_head].epoch + 1 >= current_epoch
                       or store.unrealized_justifications[head].epoch + 1 >= current_epoch)))):
         # retrieve suffix of the canonical chain
@@ -363,8 +363,7 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
             
             # The following condition can only be true the first time that we advance to a block from the current epoch
             if block_epoch > tentative_confirmed_epoch:
-                checkpoint_root = get_checkpoint_block(store, block_root, block_epoch)
-                checkpoint = Checkpoint(checkpoint_root, block_epoch)
+                checkpoint = get_checkpoint_for_block(store, block_root, block_epoch)
 
                 # To confirm blocks from the current epoch ensure that
                 # current epoch checkpoint will be justified
@@ -381,7 +380,7 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
         if (get_block_epoch(store, tentative_confirmed_root) == current_epoch
             or (get_voting_source(store, tentative_confirmed_root).epoch + 2 >= current_epoch
                 and (is_first_slot_in_epoch(get_current_slot(store))
-                     or will_no_conflicting_checkpoint_be_justified(store, get_checkpoint_block(store, head, current_epoch))))):
+                     or will_no_conflicting_checkpoint_be_justified(store, get_checkpoint_for_block(store, head, current_epoch))))):
             confirmed_root = tentative_confirmed_root
             
     return confirmed_root        

--- a/confirmation_rule.py
+++ b/confirmation_rule.py
@@ -119,7 +119,7 @@ def adjust_committee_weight_estimate_to_ensure_safety(estimate: Gwei) -> Gwei:
     return Gwei(estimate // 1000 * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR))
 
 
-def get_committee_weight_between_slots(state: BeaconState, first_slot: Slot, last_slot: Slot) -> Gwei:
+def estimate_committee_weight_between_slots(state: BeaconState, first_slot: Slot, last_slot: Slot) -> Gwei:
     """
     Returns the total weight of committees between ``first_slot`` and ``last_slot`` (inclusive of both).
     """
@@ -171,7 +171,7 @@ def is_one_confirmed(store: Store, block_root: Root) -> bool:
         weighting_checkpoint = store.prev_slot_justified_checkpoint
     weighting_checkpoint_state = store.checkpoint_states[weighting_checkpoint]
     support = get_weight(store, block_root, weighting_checkpoint_state)
-    maximum_support = get_committee_weight_between_slots(
+    maximum_support = estimate_committee_weight_between_slots(
         weighting_checkpoint_state, Slot(parent_block.slot + 1), Slot(current_slot - 1))
     proposer_score = get_proposer_score(store)
 


### PR DESCRIPTION
Deduplicate code in methods `will_current_epoch_checkpoint_be_justified()` and `will_no_conflicting_checkpoint_be_justified()`

Here is their diff in the original code: 
<img width="2858" height="952" alt="image" src="https://github.com/user-attachments/assets/93b7c0c6-0ace-47ba-9048-9ef60be56eef" />

This PR is on top of unmerged PR, please refer to the specific commit f8ff01c